### PR TITLE
change setup script to /bin/sh for increased portability

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 mkdir public
 mkdir src
 


### PR DESCRIPTION
changed shell path hint to /bin/sh to provide better portability. Will only work with POSIX compliant shells but should be good enough.